### PR TITLE
LM_keychain, LM_ds18 modification

### DIFF
--- a/micrOS/source/LM_ds18.py
+++ b/micrOS/source/LM_ds18.py
@@ -37,7 +37,7 @@ def measure():
         data.append(ds_obj.read_temp(rom))
     # Return with single data
     if len(data) == 1:
-        return {'temp [ºC]': data[0]}
+        return {'temp[C]': data[0]}
     # Return with multiple data
     return data
 

--- a/micrOS/source/LM_keychain.py
+++ b/micrOS/source/LM_keychain.py
@@ -1,16 +1,18 @@
 from LM_oled import text, show, load_n_init as oled_lni
 from LM_ds18 import measure
-from LM_neopixel import color, brightness, toggle
+from LM_neopixel import color, brightness, toggle, load_n_init as neopixel_lni
 
 INITED = False
+
 
 def load_n_init():
     """
     Init OLED display 64x32
     """
     global INITED
+    neopixel_lni(ledcnt=1)
     try:
-        oled_lni(64, 32)
+        oled_lni(128, 64)
         INITED = True
         return f'OLED INIT OK'
     except Exception as e:


### PR DESCRIPTION
LM_keychain prototype with single neopixel led and temporary display setup (128x64 --> 64x32)
LM_ds18.py string format fix for prometheus