### PR TITLE
Fix release note anchor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Access rest api over browser: `http://<nodename>.local`
 6. micrOS Node configuration [link](https://github.com/BxNxM/micrOS/#micros-node-configuration-parameters-with-description)
 7. 🧑‍💻 micrOS create custom Load Modules: [link](./APPLICATION_GUIDE.md)
 8. micrOS Gateway server with Prometheus&Grafana: [link](https://github.com/BxNxM/micrOS/#micros-gateway-in-docker)
-9. Release notes: [link](https://github.com/BxNxM/micrOS/#relese-note)
+9. Release notes: [release-note](https://github.com/BxNxM/micrOS/#release-note)
 
 ----------------------------------------
 ----------------------------------------
@@ -531,6 +531,9 @@ Version **4.0.0-0** `micrOS-???`
     - Low power mode (with BLE) and soft-sleep / deep-sleep
 ```
 
+
+<a id="release-note"></a>
+## Release notes
 
 |  VERSION (TAG) |    RELEASE INFO    |  MICROS CORE MEMORY USAGE  |  SUPPORTED DEVICE(S) | APP PROFILES | Load Modules  |     NOTE       |
 | :----------: | :----------------: | :------------------------:   |  :-----------------: | :------------: | :------------:| -------------- |


### PR DESCRIPTION
## Summary
- correct typo in release notes link
- add matching release notes anchor in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'netaddr')*
- `pip install netaddr` *(fails: Could not find a version that satisfies the requirement netaddr; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6895cc833994832ca987493963fd1334