### PR TITLE
Endpoints redesign for landing page

### DIFF
--- a/micrOS/source/web/index.html
+++ b/micrOS/source/web/index.html
@@ -47,12 +47,6 @@
           max-width:176px;
           min-width:0;
           padding:8px;
-
-          border:1px solid rgba(255,255,255,.16);
-          border-radius:8px;
-
-          background:rgba(0,0,0,.55);
-          box-shadow:0 2px 8px rgba(0,0,0,.20);
       }
 
       /* Main endpoint */
@@ -64,10 +58,10 @@
           width:100%;
           padding:6px 8px;
 
-          border:1px solid rgba(255,255,255,.16);
+          border:4px solid rgb(0, 0, 0);
           border-radius:6px;
 
-          background:rgba(255,255,255,.08);
+          background:rgba(0,0,0,.55);
           color:white;
 
           text-align:center;
@@ -96,6 +90,25 @@
           display:flex;
           flex-wrap:wrap;
           gap:8px;
+          justify-content:space-between;
+      }
+
+      .endpoint-group-actions[hidden] {
+          display:none;
+      }
+
+      .endpoint-children-toggle {
+          display:flex;
+          align-items:center;
+          justify-content:center;
+          min-height:0;
+          height:20px;
+          width:100%;
+          padding:0;
+          border:0;
+          background:transparent;
+          color:rgba(255, 255, 255, 0.55);
+          font-size:20px;
       }
 
       .endpoint-group button {
@@ -103,13 +116,20 @@
       }
 
       .endpoint-group-actions button {
+          min-width:47px;
           min-height:38px;
           padding:5px 8px;
+          background:rgba(0,0,0,.55);
+          border:2px solid rgb(0, 0, 0);
       }
 
-      @media (max-width:360px) {
+      @media (max-width: 768px) {
           .endpoint-group {
               flex-basis:126px;
+          }
+
+          .endpoint-children-toggle {
+              font-size:12px;
           }
       }
     </style>

--- a/micrOS/source/web/uapi_widgets.js
+++ b/micrOS/source/web/uapi_widgets.js
@@ -119,6 +119,27 @@ function endpointLabel(label, entry) {
     return icon ? `${icon} ${label}` : label;
 }
 
+function collapsibleToggle(label, content) {
+    const toggle = makeEl('button', {
+        className: 'endpoint-children-toggle',
+        type: 'button',
+        textContent: '\u25A0',
+        title: `Show ${label} endpoints`,
+        onclick: () => {
+            const expanded = toggle.getAttribute('aria-expanded') === 'true';
+            const action = expanded ? 'Show' : 'Hide';
+            toggle.setAttribute('aria-expanded', String(!expanded));
+            toggle.textContent = expanded ? '\u25A0' : '\u25C6';
+            toggle.title = `${action} ${label} endpoints`;
+            toggle.setAttribute('aria-label', toggle.title);
+            content.hidden = expanded;
+        }
+    });
+    toggle.setAttribute('aria-label', `Show ${label} endpoints`);
+    toggle.setAttribute('aria-expanded', 'false');
+    return toggle;
+}
+
 function renderEndpointGroups(endpoints) {
     const container = byId('endpointGroups');
     if (!container) {return;}
@@ -153,6 +174,11 @@ function renderEndpointGroups(endpoints) {
         const actions = makeEl('div', {className: 'endpoint-group-actions'});
         group.children.sort((a, b) => a.entry.localeCompare(b.entry))
             .forEach(({entry, label}) => actions.appendChild(button(endpointLabel(label, entry), entry)));
-        container.appendChild(makeEl('div', {className: 'endpoint-group'}, group.children.length ? [mainAction, actions] : [mainAction]));
+        const children = [mainAction];
+        if (group.children.length) {
+            actions.hidden = true;
+            children.push(collapsibleToggle(main, actions), actions);
+        }
+        container.appendChild(makeEl('div', {className: 'endpoint-group'}, children));
     });
 }


### PR DESCRIPTION
Endpoints section on landing page (index.html) is now redesigned to have a more aesthetic appearance.

- sub endpoint are hidden by default
- clicking on the new square button makes the sub endpoints appear
- outer dark container is refactored to be transparent
- corresponding javascript is updated, new function generates the collapsable section to aim for reusability.